### PR TITLE
feat: change maven repository resolver to maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks {
 }
 
 repositories {
-  jcenter()
+  mavenCentral()
   maven("https://dynamodb-local.s3-us-west-2.amazonaws.com/release")
 }
 dependencies {


### PR DESCRIPTION
## TL;DR
- We should remove `jcenter` maven repository setting by closing `jcenter` repository
